### PR TITLE
Make db init command independent of container ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ On the first start (after an upgrade or initial installation), the database
 needs to be migrated. Run koel init with `docker exec` in the koel runtime
 container:
 
-    docker exec -it dockerkoel_koel_1 php artisan koel:init
+    docker-compose exec koel php artisan koel:init
 
 Check out the [`./docker-compose.yml`][compose] file for more information.
 


### PR DESCRIPTION
`docker-composer up -d` names the `koel` container something like `docker-koel_koel_1_f9319c3876b6`. To the db init command work for all setups, I changed it to use docker-composer directly, where docker-compose will figure out the actual container id.