### PR TITLE
Upgrade Koel to v4.1.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -88,6 +88,7 @@ FROM php:7.2.0-apache-stretch
 # contexts.
 ARG RUNTIME_DEPS="\
   libcurl4-openssl-dev \
+  libapache2-mod-xsendfile \
   zlib1g-dev \
   libxml2-dev \
   faad \
@@ -111,6 +112,9 @@ RUN apt-get update && \
 # Copy artifacts from build stage.
 COPY --from=builder /tmp/koel /var/www/html
 
+# Copy Apache configuration
+COPY ./apache.conf /etc/apache2/sites-available/000-default.conf
+
 # Koel makes use of Larvel's pretty URLs. This requires some additional
 # configuration: https://laravel.com/docs/4.2#pretty-urls
 COPY ./.htaccess /var/www/html
@@ -118,6 +122,9 @@ COPY ./.htaccess /var/www/html
 # Fix permissions.
 RUN chown www-data:www-data /var/www/html/.htaccess
 RUN a2enmod rewrite
+
+# Music volume
+VOLUME ["/media"]
 
 # Setup bootstrap script.
 COPY koel-entrypoint /usr/local/bin/

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,6 @@
 MIT License
 
+Copyright (c) 2019 Joris Masson
 Copyright (c) 2017 Martin Charles
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ First start the koel server with a mysql database and music storage volume.
 On the first run, if the `.env` file isn't created, it will be created and the
 `APP_KEY` variable will be populated.
 
+If you provide your own `.env` file, please add the following variable to enable streaming:
+
+```
+STREAMING_METHOD=x-sendfile
+```
+
 Compose
 -------
 

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ apache and a php runtime with required extensions.
 Usage
 -----
 
-First start the koel server with a mysql database and music storage volume.
+First start the koel server with a [mysql] database and music storage volume.
 
-    docker run --name koel -p 80:80 -it 0xcaff/koel
+    docker run --name koel -p 80:80 -it hyzual/koel
 
 On the first run, if the `.env` file isn't created, it will be created and the
 `APP_KEY` variable will be populated.
@@ -21,6 +21,13 @@ If you provide your own `.env` file, please add the following variable to enable
 ```
 STREAMING_METHOD=x-sendfile
 ```
+
+### Scan media folders
+
+Whenever the music in `/media` changes, you will need to manually scan it before
+koel is able to play it. Run the following command:
+
+    docker exec koel php artisan koel:sync
 
 Compose
 -------
@@ -37,11 +44,24 @@ container:
 
 Check out the [`./docker-compose.yml`][compose] file for more information.
 
+## Volumes
+
+### /media
+
+`/media` will contain the music library. Keep in mind that koel needs to
+scan music before it's able to play it.
+
+## Ports
+
+### 80
+
+Only HTTP is provided. Consider setting up a reverse-proxy to provide HTTPS support.
+
 [dbConfig]: https://github.com/phanan/koel/blob/baa5b7af13e7f66ff1d2df1778c65757a73e478f/config/database.php
 [koel]: https://koel.phanan.net/
 [compose]: ./docker-compose.yml
-
+[mysql]: https://hub.docker.com/r/mysql/mysql-server
 [docker-compose]: https://docs.docker.com/compose/
 
-[automated-build-badge]: https://img.shields.io/docker/automated/0xcaff/koel.svg
-[docker-hub]: https://hub.docker.com/r/0xcaff/koel/
+[automated-build-badge]: https://img.shields.io/docker/automated/hyzual/koel.svg
+[docker-hub]: https://hub.docker.com/r/hyzual/koel

--- a/apache.conf
+++ b/apache.conf
@@ -1,0 +1,37 @@
+<VirtualHost *:80>
+    # The ServerName directive sets the request scheme, hostname and port that
+    # the server uses to identify itself. This is used when creating
+    # redirection URLs. In the context of virtual hosts, the ServerName
+    # specifies what hostname must appear in the request's Host: header to
+    # match this virtual host. For the default virtual host (this file) this
+    # value is not decisive as it is used as a last resort host regardless.
+    # However, you must set it for any further virtual host explicitly.
+    #ServerName www.example.com
+
+    ServerAdmin webmaster@localhost
+    DocumentRoot /var/www/html
+
+    # Available loglevels: trace8, ..., trace1, debug, info, notice, warn,
+    # error, crit, alert, emerg.
+    # It is also possible to configure the loglevel for particular
+    # modules, e.g.
+    #LogLevel info ssl:warn
+
+    ErrorLog ${APACHE_LOG_DIR}/error.log
+    CustomLog ${APACHE_LOG_DIR}/access.log combined
+
+    # For most configuration files from conf-available/, which are
+    # enabled or disabled at a global level, it is possible to
+    # include a line for only one particular virtual host. For example the
+    # following line enables the CGI configuration for this host only
+    # after it has been globally disabled with "a2disconf".
+    #Include conf-available/serve-cgi-bin.conf
+
+    LoadModule xsendfile_module   libexec/apache2/mod_xsendfile.so
+
+    # These configuration can be put in the VirtualHost directive as well
+    <IfModule mod_xsendfile.c>
+      XSendFile on
+      XSendFilePath /media
+    </IfModule>
+</VirtualHost>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.4'
 
 services:
   koel:
-    image: 0xcaff/koel
+    image: hyzual/koel
     depends_on:
       - database
     ports:
@@ -14,7 +14,7 @@ services:
       DB_PASSWORD: koel
       DB_DATABASE: koel
     volumes:
-      - music:/music
+      - music:/media
       - covers:/var/www/html/public/img/covers
 
   database:

--- a/koel-entrypoint
+++ b/koel-entrypoint
@@ -17,6 +17,7 @@ then
   # generating and storing a key file.
   echo "generating app key"
   echo "APP_KEY=$(php artisan key:generate --show)" >> .env
+  echo "STREAMING_METHOD=x-sendfile" >> .env
 else
   echo "environment file exists, skipping bootstrap"
 fi


### PR DESCRIPTION
closes #19

I also needed to upgrade a few build steps and dependencies for the upgrade to work.
This contribution upgrades koel straight to v4.1.0 (see [0]) because I was affected by the `koel:scan` regression.
Let me know if you need me to change anything.

[0]: https://github.com/phanan/koel/releases/tag/v4.1.0